### PR TITLE
Page builder preview does not working properly with bread

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -120,4 +120,15 @@
         </arguments>
     </type>
 
+    <type name="Bread\BreadCheckout\Block\Checkout\Minicart">
+        <arguments>
+            <argument name="data" xsi:type="array">
+                <item name="template" xsi:type="string">Bread_BreadCheckout::breadcheckout/minicart.phtml</item>
+                <item name="alias" xsi:type="string">breadcheckout.mini-cart</item>
+                <item name="button_id" xsi:type="string">breadcheckout-mini-cart</item>
+            </argument>
+            <argument name="payment" xsi:type="object">Bread\BreadCheckout\Model\Payment\Method\Bread</argument>
+        </arguments>
+    </type>
+
 </config>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -11,15 +11,4 @@
         <plugin name="bread-category"
                 type="Bread\BreadCheckout\Model\Plugin\ListProductPlugin" sortOrder="1"/>
     </type>
-
-    <type name="Bread\BreadCheckout\Block\Checkout\Minicart">
-        <arguments>
-            <argument name="data" xsi:type="array">
-                <item name="template" xsi:type="string">Bread_BreadCheckout::breadcheckout/minicart.phtml</item>
-                <item name="alias" xsi:type="string">breadcheckout.mini-cart</item>
-                <item name="button_id" xsi:type="string">breadcheckout-mini-cart</item>
-            </argument>
-            <argument name="payment" xsi:type="object">Bread\BreadCheckout\Model\Payment\Method\Bread</argument>
-        </arguments>
-    </type>
 </config>


### PR DESCRIPTION
This happens because the page builder preview tries to load the mini cart block, and its construct injects MethodInterface by <type>, but this type is available only on the frontend area.

![image](https://github.com/getbread/magento-v2-bread/assets/5350377/855746da-bd84-4f2a-93a4-6340fa6882bc)
![image](https://github.com/getbread/magento-v2-bread/assets/5350377/42b59112-0b5b-4b9d-9b41-658e672a2366)
