### PR TITLE
ASI-4857 - Moves sdk import to head and updates sdk init

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -80,9 +80,17 @@ class Js extends \Magento\Framework\View\Element\Text
         $moduleVersionComment = sprintf('<!-- BreadCheckout Module Version: %s -->', $this->getModuleVersion());
 
         $breadJsScript = sprintf(
-            '<script src="%s" data-api-key="%s"></script>',
-            $this->getJsLibLocation(),
-            $this->getPublicApiKey()
+            '<script data-api-key="%s">
+                const script = document.createElement("script");
+                script.async = false;
+                script.onload = () => {
+                    BreadPayments.setInitMode("manual");
+                };
+                script.src = "%s";
+                document.head.appendChild(script);
+            </script>',
+            $this->getPublicApiKey(),
+            $this->getJsLibLocation()
         );
 
         return $moduleVersionComment . $breadJsScript;

--- a/Block/Js.php
+++ b/Block/Js.php
@@ -84,7 +84,11 @@ class Js extends \Magento\Framework\View\Element\Text
                 const script = document.createElement("script");
                 script.async = false;
                 script.onload = () => {
-                    BreadPayments.setInitMode("manual");
+                    if (BreadPayments) {
+                        BreadPayments.setInitMode("manual");
+                    } else {
+                     RBCPayPlan.setInitMode("manual");
+                    }
                 };
                 script.src = "%s";
                 document.head.appendChild(script);

--- a/view/adminhtml/templates/breadcheckout/info.phtml
+++ b/view/adminhtml/templates/breadcheckout/info.phtml
@@ -74,7 +74,7 @@ $storeId = $block->saveAdminStoreId();
             });
         };
 
-        $(document).ready(function() {
+        $(window).on('load', function() {
             if ($('#edit_form').find(':radio[name="payment[method]"]:checked').val() == '<?= /* @noEscape */ $code; ?>') {
                 getQuoteData();
             }

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -2,7 +2,7 @@
 
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="content">
+        <referenceContainer name="head.additional">
             <block class="Bread\BreadCheckout\Block\Js" as="breadcheckout.prod.js" name="breadcheckout.prod.js"/>
         </referenceContainer>
         <referenceContainer name="after.body.start">

--- a/view/frontend/templates/breadcheckout/bundle.phtml
+++ b/view/frontend/templates/breadcheckout/bundle.phtml
@@ -227,7 +227,7 @@ require([
             }
         });
 
-        $(document).ready(function() {
+        $(window).on('load', function() {
             $(bundleConfig.buttonPrimaryCustom).on('click', function() {
                 $(bundleConfig.bundleButtonSel).appendTo(bundleConfig.bundleButtonDetailsContSel);
                 $(bundleConfig.addToCartForm).bundleBread();

--- a/view/frontend/templates/breadcheckout/catalog/product/view.phtml
+++ b/view/frontend/templates/breadcheckout/catalog/product/view.phtml
@@ -17,7 +17,7 @@
 ?>
     <script type="text/javascript">
             require(['jquery'], function ($) {
-                $(document).ready(function () {
+                $(window).on('load', function() {
                     var allowCheckout = false;
                     var buttonLocation = '<?= /* @noEscape */ $block->getCategoryPageLocation(); ?>';
                     var integrationKey = '<?= /* @noEscape */ $block->getIntegrationKey(); ?>';

--- a/view/frontend/templates/breadcheckout/configurable.phtml
+++ b/view/frontend/templates/breadcheckout/configurable.phtml
@@ -10,7 +10,7 @@
     document.Skus = {};
     spConfig = <?= /* @noEscape */ $block->getJsonConfig(); ?>;
     require(['jquery', 'underscore'], function ($, _) {
-        $(document).ready(function () {
+        $(window).on('load', function() {
             /**
              * Overlay element onto bread button to prevent
              * it from being clicked until options are selected
@@ -129,7 +129,7 @@ if (!empty($itemIds)) {
     spConfig = <?= /* @noEscape */ $block->getJsonConfig(); ?>;
 
     require(['jquery', 'underscore'], function ($, _) {
-        $(document).ready(function () {
+        $(window).on('load', function() {
             /**
              * Overlay element onto bread button to prevent
              * it from being clicked until options are selected

--- a/view/frontend/templates/breadcheckout/grouped.phtml
+++ b/view/frontend/templates/breadcheckout/grouped.phtml
@@ -106,7 +106,7 @@
                     } 
                 }
             };
-            $(document).ready(function() {
+            $(window).on('load', function() {
                 $('#loading-items').hide();
                 $('#product_addtocart_form').on('change', function() {
                     document.updateButton(this);
@@ -349,7 +349,7 @@
                         'Error code returned when calling ' + configDataUrl + ', with status: ' + error.statusText);
                 });
                 };
-                        $(document).ready(function() {
+                $(window).on('load', function() {
 
                 /**
                  * Overlay element onto bread button to prevent

--- a/view/frontend/templates/breadcheckout/list_product.phtml
+++ b/view/frontend/templates/breadcheckout/list_product.phtml
@@ -92,7 +92,7 @@ $apiVersion = $block->getApiVersion();
             }
         };
 
-        $(document).ready(function () {
+        $(window).on('load', function() {
             <?php
             $data = $block->getProductDataJson($product);
             ?>

--- a/view/frontend/templates/breadcheckout/minicart.phtml
+++ b/view/frontend/templates/breadcheckout/minicart.phtml
@@ -81,7 +81,7 @@
             
         };
         
-        $(document).ready(function() {
+        $(window).on('load', function() {
             var minicartItems       = <?= /* @noEscape */ $block->getProductDataJson(); ?>;
             document.configureButton(minicartItems);
         });
@@ -289,7 +289,7 @@
             return parseInt(Math.round(value * 100));
         };
 
-        $(document).ready(function() {
+        $(window).on('load', function() {
             var minicartItems       = <?= /* @noEscape */ $block->getProductDataJson(); ?>;
             document.configureButton(minicartItems);
         });

--- a/view/frontend/templates/breadcheckout/price.phtml
+++ b/view/frontend/templates/breadcheckout/price.phtml
@@ -140,7 +140,7 @@
         document.splitPayPreviousPrice      = document.splitPayDefaultItems[0]["price"];
         document.splitPayPreviousSku        = document.splitPayDefaultItems[0]["sku"];
 
-        $(document).ready(function () {
+        $(window).on('load', function() {
             <?php if ($block->getProduct() != null) : ?>
             document.splitPayProductId                      = '<?= /* @noEscape */ $block->getProduct()->getId(); ?>';
             document.splitPayBaseProductSku                 = '<?= /* @noEscape */ $block->getProduct()->getSku(); ?>';

--- a/view/frontend/templates/breadcheckout/view.phtml
+++ b/view/frontend/templates/breadcheckout/view.phtml
@@ -173,7 +173,7 @@
         document.previousPrice      = document.defaultItems[0]["price"];
         document.previousSku        = document.defaultItems[0]["sku"];
 
-        $(document).ready(function () {
+        $(window).on('load', function() {
             <?php if ($block->getProduct() != null) : ?>
                 document.productId                      = '<?= /* @noEscape */ $block->getProduct()->getId(); ?>';
                 document.baseProductSku                 = '<?= /* @noEscape */ $block->getProduct()->getSku(); ?>';
@@ -478,7 +478,7 @@
         document.previousPrice      = document.defaultItems[0]["price"];
         document.previousSku        = document.defaultItems[0]["sku"];
 
-        $(document).ready(function () {
+        $(window).on('load', function() {
             <?php if ($block->getProduct() != null) : ?>
                 document.productId                      = '<?= /* @noEscape */ $block->getProduct()->getId(); ?>';
                 document.baseProductSku                 = '<?= /* @noEscape */ $block->getProduct()->getSku(); ?>';


### PR DESCRIPTION
JIRA Ticket: https://breadfinance.atlassian.net/browse/ASI-4857

This PR fixes the error in the console for the plugin that read: `“There's an error in Magento Bread sdk.js script, which occurs on every product page where Bread is loaded.`

This happened for a couple reasons:
1. The sdk was being loaded in the body of the html instead of the head block as intended.
2. The setup was happening on document.ready whereas the SDK was already being initialized on load.

To fix this, this PR moved the SDK script in the default.xml file to be loaded in the head block. It also set the init mode to manual and the setup to on window "load" instead of on document.ready.


