### PR TITLE
Release 2.4.5-p1

### DIFF
--- a/Block/Js.php
+++ b/Block/Js.php
@@ -20,35 +20,14 @@ class Js extends \Magento\Framework\View\Element\Text
      */
     private $packageInfo;
 
-    /**
-     * @var \Magento\Framework\App\CacheInterface
-     */
-    public $cache;
-
-    /**
-     * @var \Magento\Framework\HTTP\Client\Curl
-     */
-    protected $curl;
-
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    public $logger;
-
     public function __construct(
         \Magento\Framework\View\Element\Context $context,
         \Bread\BreadCheckout\Helper\Data $helper,
         \Magento\Framework\Module\PackageInfo $packageInfo,
-        \Magento\Framework\App\CacheInterface $cache,
-        \Magento\Framework\HTTP\Client\Curl $curl,
-        \Bread\BreadCheckout\Helper\Log $logger,
         array $data = []
     ) {
         $this->helper = $helper;
         $this->packageInfo = $packageInfo;
-        $this->cache = $cache;
-        $this->curl = $curl;
-        $this->logger = $logger;
 
         parent::__construct(
             $context,

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in 
 # the repo. Unless a later match takes precedence,
-* @dschoder-bread @chris-asmar @fkhan-bread @jdunn-bread
+* @serzhik

--- a/Observer/SaveBreadApiVersionObserver.php
+++ b/Observer/SaveBreadApiVersionObserver.php
@@ -67,18 +67,21 @@ class SaveBreadApiVersionObserver implements ObserverInterface
      * @throws NoSuchEntityException
      */
     public function execute(EventObserver $observer) {
-
         if ($this->_state->getAreaCode() != \Magento\Framework\App\Area::AREA_ADMINHTML) {
             $paymentOrder = $observer->getEvent()->getPayment();
             $order = $paymentOrder->getOrder();
             if (!$order->getQuoteId()) {
                 return;
             }
-            $quote = $this->_quoteRepository->get($order->getQuoteId());
-            $paymentQuote = $quote->getPayment();
-            $method = $paymentQuote->getMethodInstance()->getCode();
-            if ($method === \Bread\BreadCheckout\Model\Ui\ConfigProvider::CODE) {
-                $paymentOrder->setData('bread_api_version', $this->helper->getApiVersion());
+            try {
+                $quote = $this->_quoteRepository->get($order->getQuoteId());
+                $paymentQuote = $quote->getPayment();
+                $method = $paymentQuote->getMethodInstance()->getCode();
+                if ($method === \Bread\BreadCheckout\Model\Ui\ConfigProvider::CODE) {
+                    $paymentOrder->setData('bread_api_version', $this->helper->getApiVersion());
+                }
+            // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+            } catch (NoSuchEntityException $e) {
             }
         }
     }

--- a/Observer/SaveBreadApiVersionObserver.php
+++ b/Observer/SaveBreadApiVersionObserver.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Save bread API version for transactions that belong to Bread payment
  * method
@@ -7,42 +6,50 @@
  * @since 2.3.0
  * @author Maritim, Kip
  */
-
 namespace Bread\BreadCheckout\Observer;
 
+use Bread\BreadCheckout\Helper\Log;
+use Bread\BreadCheckout\Helper\Quote as Helper;
+use Magento\Framework\App\State;
 use Magento\Framework\Event\Observer as EventObserver;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Model\QuoteRepository;
 
-class SaveBreadApiVersionObserver implements ObserverInterface {
-
+class SaveBreadApiVersionObserver implements ObserverInterface
+{
     /**
-     * 
-     * @var type
+     * @var Log
      */
     protected $logger;
 
     /**
-     * 
-     * @var type
+     * @var State
      */
     protected $_state;
 
     /**
-     * @var object 
+     * @var QuoteRepository
      */
     protected $_quoteRepository;
+
+    /**
+     * @var Helper
+     */
     protected $helper;
 
     /**
-     * 
-     * @param \Bread\BreadCheckout\Helper\Log $logger
-     * @param \Magento\Framework\App\State $state
+     * @param Log             $logger
+     * @param State           $state
+     * @param QuoteRepository $quoteRepository
+     * @param Helper          $helper
      */
     public function __construct(
-            \Bread\BreadCheckout\Helper\Log $logger,
-            \Magento\Framework\App\State $state,
-            \Magento\Quote\Model\QuoteRepository $quoteRepository,
-            \Bread\BreadCheckout\Helper\Quote $helper
+        Log $logger,
+        State $state,
+        QuoteRepository $quoteRepository,
+        Helper $helper
     ) {
         $this->logger = $logger;
         $this->_state = $state;
@@ -51,14 +58,22 @@ class SaveBreadApiVersionObserver implements ObserverInterface {
     }
 
     /**
-     * 
-     * @param EventObserver $observer
+     * Executes the observer logic for processing payment data during specific events.
+     *
+     * @param EventObserver $observer The observer object that contains event data such as payment and order information.
+     *
+     * @return void
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
      */
     public function execute(EventObserver $observer) {
 
         if ($this->_state->getAreaCode() != \Magento\Framework\App\Area::AREA_ADMINHTML) {
             $paymentOrder = $observer->getEvent()->getPayment();
             $order = $paymentOrder->getOrder();
+            if (!$order->getQuoteId()) {
+                return;
+            }
             $quote = $this->_quoteRepository->get($order->getQuoteId());
             $paymentQuote = $quote->getPayment();
             $method = $paymentQuote->getMethodInstance()->getCode();
@@ -67,5 +82,4 @@ class SaveBreadApiVersionObserver implements ObserverInterface {
             }
         }
     }
-
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Installation
 
 2. Install the Bread Checkout module    
      ```bash
-     composer require breadfinance/module-breadcheckout
+     composer require zghraia/magento2-bread-payment
      ```
 3. For Canada Merchants only
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,14 @@
 == Changelog ==
 
+= 2.4.5-p1
+* Removes support of old versions
+* Removes unused dependencies in Block\Js.php
+* Show correct error in console when SDK is not loaded (for example, when blocked by country)
+* Adds default values for some configurations and add option to restore default values
+* Adds `*.breadgateway.net` to `connect-src` policy in `csp_whitelist.xml`
+* Fixed SaveBreadApiVersionObserver. `quote_id` in `sales_order` table can be `null`
+
+
 = 2.4.5
 * Current release
 * Use base_grand_total instead of base_total
@@ -44,7 +53,7 @@
 * Category page slow load bug fix
 
 = 2.3.3
-* PHP 8.2 comaptibility updates
+* PHP 8.2 compatibility updates
 * Healthcare mode refactor, healthcare checks have been moved to the SDK
 * Closed https://github.com/getbread/magento-v2-bread/issues/189
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "version": "2.4.5",
     "require": {
-        "php": "~7.0.13||~7.1.0||~7.1.3||~7.2.0||~7.3.0||~7.4.0||~8.0.0||~8.1.0||~8.2.0"
+        "php": "~8.1.0||~8.2.0"
     },
     "type": "magento2-module",
     "repositories": [{

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,19 @@
 {
-    "name": "bread/module-breadcheckout",
+    "name": "zghraia/magento2-bread-payment",
     "description": "Offers Bread Pay financing and checkout tools for your Magento store",
     "license": "MIT",
     "minimum-stability": "stable",
     "version": "2.4.5",
     "require": {
-        "php": "~8.1.0||~8.2.0"
+        "php": "8.1.0||~8.2.0||~8.3.0||~8.4.0"
     },
     "type": "magento2-module",
+    "conflict": {
+        "breadfinance/module-breadcheckout": "*"
+    },
     "repositories": [{
         "type": "vcs",
-        "url": "git@github.com:getbread/magento-v2-bread.git"
+        "url": "git@github.com:zghraia/magento2-bread-payment.git"
     }],
     "autoload": {
         "files": ["registration.php"],

--- a/etc/adminhtml/system.ca.us.xml
+++ b/etc/adminhtml/system.ca.us.xml
@@ -120,14 +120,14 @@
                     <comment>The Position In the Payment Method List In Checkout</comment>
                     <validate>validate-number</validate>
                 </field>
-                <field id="enabled_on_product_page" type="select" sortOrder="15" translate="label" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enabled_on_product_page" type="select" sortOrder="15" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enabled on Product Details Page</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="active">1</field>
                     </depends>
                 </field>
-                <field id="enabled_on_cart_page" type="select" sortOrder="16" translate="label" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enabled_on_cart_page" type="select" sortOrder="16" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enabled on Cart Overview Page</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
@@ -250,7 +250,7 @@
                         <field id="api_version">classic</field>
                     </depends>
                 </field>
-                <field id="enableonminicart" type="select" sortOrder="28" translate="label" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enableonminicart" type="select" sortOrder="28" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enabled on Minicart page</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>

--- a/etc/adminhtml/system.ca.xml
+++ b/etc/adminhtml/system.ca.xml
@@ -76,21 +76,21 @@
                     <comment>The Position In the Payment Method List In Checkout</comment>
                     <validate>validate-number</validate>
                 </field>
-                <field id="enabled_on_product_page" type="select" sortOrder="10" translate="label" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enabled_on_product_page" type="select" sortOrder="10" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enabled on Product Details Page</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="active">1</field>
                     </depends>
                 </field>
-                <field id="enableonminicart" type="select" sortOrder="11" translate="label" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enableonminicart" type="select" sortOrder="11" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enabled on Minicart page</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="active">1</field>
                     </depends>
                 </field>
-                <field id="enabled_on_cart_page" type="select" sortOrder="12" translate="label" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enabled_on_cart_page" type="select" sortOrder="12" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enabled on Cart Overview Page</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -120,14 +120,14 @@
                     <comment>The Position In the Payment Method List In Checkout</comment>
                     <validate>validate-number</validate>
                 </field>
-                <field id="enabled_on_product_page" type="select" sortOrder="15" translate="label" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enabled_on_product_page" type="select" sortOrder="15" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enabled on Product Details Page</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="active">1</field>
                     </depends>
                 </field>
-                <field id="enabled_on_cart_page" type="select" sortOrder="16" translate="label" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enabled_on_cart_page" type="select" sortOrder="16" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enabled on Cart Overview Page</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
@@ -250,7 +250,7 @@
                         <field id="api_version">classic</field>
                     </depends>
                 </field>
-                <field id="enableonminicart" type="select" sortOrder="28" translate="label" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enableonminicart" type="select" sortOrder="28" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enabled on Minicart page</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -29,6 +29,9 @@
                 <bread_category>
                     <use_default_button_size>1</use_default_button_size>
                 </bread_category>
+                <enabled_on_product_page>0</enabled_on_product_page>
+                <enabled_on_cart_page>0</enabled_on_cart_page>
+                <enableonminicart>0</enableonminicart>
             </breadcheckout>
             <rbccheckout>
                 <active>1</active>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -11,6 +11,7 @@
         <policy id="connect-src">
             <values>
                 <value id="bread_classic_connect" type="host">*.getbread.com</value>
+                <value id="bread_gateway_connect" type="host">*.breadgateway.net</value>
                 <value id="bread_platform_connect" type="host">*.breadpayments.com</value>
                 <value id="bread_platform_connect_ca" type="host">*.rbcpayplan.com</value>
             </values>

--- a/view/frontend/templates/breadcheckout/view.phtml
+++ b/view/frontend/templates/breadcheckout/view.phtml
@@ -114,7 +114,11 @@
                 let errorInfo = {
                     err: 'err'
                 };
-                document.logBreadIssue('error', errorInfo, 'Instance of Bread Payments SDK does not exist');
+                try {
+                    document.logBreadIssue('error', errorInfo, 'Instance of Bread Payments SDK does not exist');
+                } catch (error) {
+                    console.error('Instance of Bread Payments SDK does not exist');
+                }
             }
         };    
             


### PR DESCRIPTION
* Removes support of old versions
* Removes unused dependencies in Block\Js.php
* Show correct error in console when SDK is not loaded (for example, when blocked by country)
* Adds default values for some configurations and add option to restore default values
* Adds `*.breadgateway.net` to `connect-src` policy in `csp_whitelist.xml`
* Fixed SaveBreadApiVersionObserver. `quote_id` in `sales_order` table can be `null`