### PR TITLE
Remove deprecated `setup_version` from module.xml

### DIFF
--- a/Setup/Patch/Data/CopyApiCredentials.php
+++ b/Setup/Patch/Data/CopyApiCredentials.php
@@ -90,9 +90,4 @@ class CopyApiCredentials implements DataPatchInterface
     {
         return [];
     }
-
-    public static function getVersion()
-    {
-        return '2.3.0';
-    }
 }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Bread_BreadCheckout" setup_version="2.4.6">
+    <module name="Bread_BreadCheckout">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
`setup_version` is deprecated and is not needed for declarative schema.

Patch used `getVersion` method, but it does not implement `\Magento\Framework\Setup\Patch\PatchVersionInterface`