### PR TITLE
Replace deprecated `\Magento\Framewfork\Option\ArrayInterface` with `\Magento\Framewfork\Option\OptionSourceInterface`

### DIFF
--- a/Model/System/Config/Source/ApiMode.php
+++ b/Model/System/Config/Source/ApiMode.php
@@ -6,11 +6,14 @@
  * @author Joel    @Mediotype
  * @author Miranda @Mediotype
  */
+declare(strict_types=1);
+
 namespace Bread\BreadCheckout\Model\System\Config\Source;
 
-class ApiMode implements \Magento\Framework\Option\ArrayInterface
-{
+use Magento\Framework\Data\OptionSourceInterface;
 
+class ApiMode implements OptionSourceInterface
+{
     /**
      * Options getter
      *

--- a/Model/System/Config/Source/ApiVersion.php
+++ b/Model/System/Config/Source/ApiVersion.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * API version options
  *
@@ -7,11 +6,14 @@
  * @since 2.1.0
  * @author Kiprotich, Maritim <kip.maritim@breadfinancial.com>
  */
+declare(strict_types=1);
 
 namespace Bread\BreadCheckout\Model\System\Config\Source;
 
-class ApiVersion implements \Magento\Framework\Option\ArrayInterface {
+use Magento\Framework\Data\OptionSourceInterface;
 
+class ApiVersion implements OptionSourceInterface
+{
     /**
      * Options getter
      *
@@ -35,5 +37,4 @@ class ApiVersion implements \Magento\Framework\Option\ArrayInterface {
             'bread_2' => __('Bread Platform')
         ];
     }
-
 }

--- a/Model/System/Config/Source/ApiVersionRbc.php
+++ b/Model/System/Config/Source/ApiVersionRbc.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * API version options
  *
@@ -7,11 +6,14 @@
  * @since 2.1.0
  * @author Kiprotich, Maritim <kip.maritim@breadfinancial.com>
  */
+declare(strict_types=1);
 
 namespace Bread\BreadCheckout\Model\System\Config\Source;
 
-class ApiVersionRbc implements \Magento\Framework\Option\ArrayInterface {
+use Magento\Framework\Data\OptionSourceInterface;
 
+class ApiVersionRbc implements OptionSourceInterface
+{
     /**
      * Options getter
      *
@@ -33,5 +35,4 @@ class ApiVersionRbc implements \Magento\Framework\Option\ArrayInterface {
             'bread_2' => __('Bread 2.0')
         ];
     }
-
 }

--- a/Model/System/Config/Source/TargetedFinancing.php
+++ b/Model/System/Config/Source/TargetedFinancing.php
@@ -1,8 +1,11 @@
 <?php
+declare(strict_types = 1);
 
 namespace Bread\BreadCheckout\Model\System\Config\Source;
 
-class TargetedFinancing implements \Magento\Framework\Option\ArrayInterface
+use Magento\Framework\Data\OptionSourceInterface;
+
+class TargetedFinancing implements OptionSourceInterface
 {
     /**
      * Options getter
@@ -11,7 +14,11 @@ class TargetedFinancing implements \Magento\Framework\Option\ArrayInterface
      */
     public function toOptionArray()
     {
-        return [['value' => 0, 'label' => __('No')], ['value' => 1, 'label' => __('By Cart Size')], ['value' => 2, 'label' => __('By SKU List')]];
+        return [
+            ['value' => 0, 'label' => __('No')],
+            ['value' => 1, 'label' => __('By Cart Size')],
+            ['value' => 2, 'label' => __('By SKU List')]
+        ];
     }
 
     /**
@@ -21,6 +28,10 @@ class TargetedFinancing implements \Magento\Framework\Option\ArrayInterface
      */
     public function toArray()
     {
-        return [0 => __('No'), 1 => __('By Cart Size'), 2 => __('By SKU List')];
+        return [
+            0 => __('No'),
+            1 => __('By Cart Size'),
+            2 => __('By SKU List')
+        ];
     }
 }

--- a/Model/System/Config/Source/Tenant.php
+++ b/Model/System/Config/Source/Tenant.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * API version options
  *
@@ -7,17 +6,21 @@
  * @copyright (c) Bread
  * @author Kip, Maritim <kip.maritim@breadfinancial.com>
  */
+declare(strict_types=1);
 
 namespace Bread\BreadCheckout\Model\System\Config\Source;
 
-class Tenant implements \Magento\Framework\Option\ArrayInterface {
+use Magento\Framework\Data\OptionSourceInterface;
 
+class Tenant implements OptionSourceInterface
+{
     /**
      * Options getter
      *
      * @return array
      */
-    public function toOptionArray() {
+    public function toOptionArray()
+    {
         return [
             ['value' => 'core', 'label' => __('CORE (US)')],
         ];
@@ -28,10 +31,10 @@ class Tenant implements \Magento\Framework\Option\ArrayInterface {
      *
      * @return array
      */
-    public function toArray() {
+    public function toArray()
+    {
         return [
             'core' => __('CORE (US'),
         ];
     }
-
 }

--- a/Model/System/Config/Source/TenantRbc.php
+++ b/Model/System/Config/Source/TenantRbc.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * API version options
  *
@@ -7,17 +6,21 @@
  * @copyright (c) Bread
  * @author Kip, Maritim <kip.maritim@breadfinancial.com>
  */
+declare(strict_types=1);
 
 namespace Bread\BreadCheckout\Model\System\Config\Source;
 
-class TenantRbc implements \Magento\Framework\Option\ArrayInterface {
+use Magento\Framework\Data\OptionSourceInterface;
 
+class TenantRbc implements OptionSourceInterface
+{
     /**
      * Options getter
      *
      * @return array
      */
-    public function toOptionArray() {
+    public function toOptionArray()
+    {
         return [
             ['value' => 'rbc', 'label' => __('Payplan by RBC')],
         ];
@@ -28,10 +31,10 @@ class TenantRbc implements \Magento\Framework\Option\ArrayInterface {
      *
      * @return array
      */
-    public function toArray() {
+    public function toArray()
+    {
         return [
             'rbc' => __('Payplan by RBC'),
         ];
     }
-
 }


### PR DESCRIPTION
Replace deprecated `\Magento\Framewfork\Option\ArrayInterface` with `\Magento\Framewfork\Option\OptionSourceInterface`