### PR TITLE
2026 Guidepoint Bread Pay Plugins - Magento SCR: M3 Cryptographic Keys Stored Insecurely

### DIFF
--- a/Controller/Adminhtml/Bread/ValidateCredentials.php
+++ b/Controller/Adminhtml/Bread/ValidateCredentials.php
@@ -133,13 +133,13 @@ class ValidateCredentials extends \Magento\Backend\App\Action {
                 
                 if (isset($response['token'])) {
                     $tenantLoaded = true;
-                    $this->configWriter->save('payment/breadcheckout/bread_auth_token', $response['token'], 'default');
+                    $this->dataHelper->saveAuthToken($response['token']);
                     $this->configWriter->save('payment/breadcheckout/tenant', $tenant, 'default');
                     return true;
                 }
             }
             // Case for all api urls calls returning status != 200 or token is not set in response
-            $this->configWriter->save('payment/breadcheckout/bread_auth_token', "0", 'default');
+            $this->dataHelper->saveAuthToken("0");
             $this->configWriter->save('payment/breadcheckout/tenant', $tenant, 'default');
             return false;
         } catch (Exception $ex) {

--- a/Helper/Catalog.php
+++ b/Helper/Catalog.php
@@ -33,12 +33,13 @@ class Catalog extends Data
         \Magento\Framework\Encryption\Encryptor $encryptor,
         \Magento\Framework\UrlInterfaceFactory $urlInterfaceFactory,
         \Magento\Catalog\Api\ProductRepositoryInterfaceFactory $productRepositoryFactory,
-        \Magento\Store\Model\StoreManagerInterface $storeManager
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Framework\App\Config\Storage\WriterInterface $configWriter
     ) {
         $this->productViewBlock = $productViewBlock;
         $this->productRepositoryFactory = $productRepositoryFactory;
         $this->storeManager = $storeManager;
-        parent::__construct($helperContext, $context, $request, $encryptor, $urlInterfaceFactory, $storeManager);
+        parent::__construct($helperContext, $context, $request, $encryptor, $urlInterfaceFactory, $storeManager, $configWriter);
     }
 
     /**

--- a/Helper/Checkout.php
+++ b/Helper/Checkout.php
@@ -30,7 +30,8 @@ class Checkout extends Quote
         \Bread\BreadCheckout\Model\Payment\Api\Client $paymentApiClient,
         \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
         \Bread\BreadCheckout\Helper\Log $logger,
-        \Magento\Store\Model\StoreManagerInterface $storeManager    
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Framework\App\Config\Storage\WriterInterface $configWriter
     ) {
         $this->logger = $logger;
         parent::__construct(
@@ -45,7 +46,8 @@ class Checkout extends Quote
             $priceCurrency,
             $paymentApiClient,
             $productRepository,
-            $storeManager    
+            $storeManager,
+            $configWriter
         );
     }
 

--- a/Helper/Customer.php
+++ b/Helper/Customer.php
@@ -87,7 +87,8 @@ class Customer extends Data
         \Magento\Directory\Model\RegionFactory $regionFactory,
         \Magento\Customer\Api\CustomerRepositoryInterface $customerRepository,
         \Magento\Customer\Api\AddressRepositoryInterface $addressRepository,
-        \Bread\BreadCheckout\Helper\Log $logger  
+        \Bread\BreadCheckout\Helper\Log $logger,
+        \Magento\Framework\App\Config\Storage\WriterInterface $configWriter
     ) {
         $this->storeManager = $storeManager;
         $this->customerSession = $customerSession;
@@ -101,7 +102,7 @@ class Customer extends Data
         $this->customerRepository = $customerRepository;
         $this->addressRepository = $addressRepository;
         $this->logger = $logger;
-        parent::__construct($helperContext, $context, $request, $encryptor, $urlInterfaceFactory, $storeManager);
+        parent::__construct($helperContext, $context, $request, $encryptor, $urlInterfaceFactory, $storeManager, $configWriter);
     }
     /**
      * Pass Back Bread Formatted Default Customer Address If It Exists

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -146,6 +146,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper {
     public $encryptor;
 
     /**
+     * @var \Magento\Framework\App\Config\Storage\WriterInterface
+     */
+    public $configWriter;
+
+    /**
      * @var \Magento\Framework\UrlInterfaceFactory
      */
     public $urlInterfaceFactory;
@@ -234,6 +239,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper {
      * @param \Magento\Framework\Encryption\Encryptor $encryptor
      * @param \Magento\Framework\UrlInterfaceFactory $urlInterfaceFactory
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Framework\App\Config\Storage\WriterInterface $configWriter
      */
     public function __construct(
             \Magento\Framework\App\Helper\Context $helperContext,
@@ -241,7 +247,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper {
             \Magento\Framework\App\Request\Http $request,
             \Magento\Framework\Encryption\Encryptor $encryptor,
             \Magento\Framework\UrlInterfaceFactory $urlInterfaceFactory,
-            \Magento\Store\Model\StoreManagerInterface $storeManager
+            \Magento\Store\Model\StoreManagerInterface $storeManager,
+            \Magento\Framework\App\Config\Storage\WriterInterface $configWriter
     ) {
         $this->context = $context;
         $this->request = $request;
@@ -249,6 +256,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper {
         $this->encryptor = $encryptor;
         $this->urlInterfaceFactory = $urlInterfaceFactory;
         $this->storeManager = $storeManager;
+        $this->configWriter = $configWriter;
         parent::__construct(
                 $helperContext
         );
@@ -1166,7 +1174,29 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper {
      * @return type
      */
     public function getAuthToken($storeCode = null, $store = \Magento\Store\Model\ScopeInterface::SCOPE_STORE) {
-        return $this->getConfigValue("XML_CONFIG_AUTH_TOKEN", $store, $storeCode);
+        $authToken = $this->getConfigValue("XML_CONFIG_AUTH_TOKEN", $store, $storeCode);
+        if ($authToken === null || $authToken === '') {
+            return $authToken;
+        }
+        if (substr_count($authToken, '.') === 2) {
+            return $authToken;
+        }
+        return (string) $this->encryptor->decrypt($authToken);
+    }
+
+    /**
+     * Encrypt and persist the auth token, mirroring how other sensitive config values are stored
+     *
+     * @param string $authToken
+     * @param string $scope
+     * @return void
+     */
+    public function saveAuthToken($authToken, $scope = 'default') {
+        $this->configWriter->save(
+                self::XML_CONFIG_AUTH_TOKEN,
+                $this->encryptor->encrypt((string) $authToken),
+                $scope
+        );
     }
     
     /**

--- a/Helper/Quote.php
+++ b/Helper/Quote.php
@@ -76,7 +76,8 @@ class Quote extends Data
         \Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency,
         \Bread\BreadCheckout\Model\Payment\Api\Client $paymentApiClient,
         \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
-        \Magento\Store\Model\StoreManagerInterface $storeManager    
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Framework\App\Config\Storage\WriterInterface $configWriter
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->helperCatalog = $helperCatalog;
@@ -91,7 +92,8 @@ class Quote extends Data
             $request,
             $encryptor,
             $urlInterfaceFactory,
-            $storeManager    
+            $storeManager,
+            $configWriter
         );
     }
 

--- a/Helper/Url.php
+++ b/Helper/Url.php
@@ -17,10 +17,11 @@ class Url extends Data
         \Magento\Framework\Encryption\Encryptor $encryptor,
         \Magento\Framework\UrlInterfaceFactory $urlInterfaceFactory,
         \Magento\Framework\Url $urlHelper,
-        \Magento\Store\Model\StoreManagerInterface $storeManager    
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Framework\App\Config\Storage\WriterInterface $configWriter
     ) {
         $this->urlHelper = $urlHelper;
-        parent::__construct($helperContext, $context, $request, $encryptor, $urlInterfaceFactory, $storeManager);
+        parent::__construct($helperContext, $context, $request, $encryptor, $urlInterfaceFactory, $storeManager, $configWriter);
     }
 
     /**

--- a/Model/Payment/Api/Client.php
+++ b/Model/Payment/Api/Client.php
@@ -507,7 +507,7 @@ class Client extends \Magento\Framework\Model\AbstractModel
                     $getToken = $this->generateAuthToken($authTokenUrl, $username, $password);
                     if (isset($getToken['token'])) {
                         $authToken = $getToken['token'];
-                        $this->configWriter->save('payment/breadcheckout/bread_auth_token', $authToken, 'default');
+                        $this->helper->saveAuthToken($authToken);
                     } else {
                         $errorMessage = 'Call to Bread APIs failed.';
                         throw new \Magento\Framework\Exception\LocalizedException(
@@ -523,7 +523,7 @@ class Client extends \Magento\Framework\Model\AbstractModel
                     $getToken = $this->generateAuthToken($authTokenUrl, $username, $password);
                     if (isset($getToken['token'])) {
                         $authToken = $getToken['token'];
-                        $this->configWriter->save('payment/breadcheckout/bread_auth_token', $authToken, 'default');
+                        $this->helper->saveAuthToken($authToken);
 
                         $response = $this->callBread($url, $authToken, $data, $method, $jsonEncode);
 

--- a/Setup/Patch/Data/EncryptAuthTokens.php
+++ b/Setup/Patch/Data/EncryptAuthTokens.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Bread\BreadCheckout\Setup\Patch\Data;
+
+use Magento\Framework\App\Cache\Type\Config;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+class EncryptAuthTokens implements DataPatchInterface
+{
+    private const AUTH_TOKEN_PATH = 'payment/breadcheckout/bread_auth_token';
+
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    private $moduleDataSetup;
+
+    /**
+     * @var EncryptorInterface
+     */
+    private $encryptor;
+
+    /**
+     * @var TypeListInterface
+     */
+    private $cacheTypeList;
+
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup,
+        EncryptorInterface $encryptor,
+        TypeListInterface $cacheTypeList
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+        $this->encryptor = $encryptor;
+        $this->cacheTypeList = $cacheTypeList;
+    }
+
+    public function apply()
+    {
+        $this->moduleDataSetup->startSetup();
+
+        $connection = $this->moduleDataSetup->getConnection();
+        $table = $this->moduleDataSetup->getTable('core_config_data');
+        $rows = $connection->fetchAll(
+            $connection->select()
+                ->from($table, ['config_id', 'value'])
+                ->where('path = ?', self::AUTH_TOKEN_PATH)
+        );
+
+        foreach ($rows as $row) {
+            $value = $row['value'];
+            if ($value === null || $value === '' || preg_match('/^\d+:\d+:/', $value)) {
+                continue;
+            }
+
+            $connection->update(
+                $table,
+                ['value' => $this->encryptor->encrypt($value)],
+                ['config_id = ?' => (int) $row['config_id']]
+            );
+        }
+
+        $this->cacheTypeList->cleanType(Config::TYPE_IDENTIFIER);
+        $this->moduleDataSetup->endSetup();
+    }
+
+    public static function getDependencies()
+    {
+        return [];
+    }
+
+    public function getAliases()
+    {
+        return [];
+    }
+}

--- a/Setup/Patch/Data/EncryptAuthTokens.php
+++ b/Setup/Patch/Data/EncryptAuthTokens.php
@@ -51,7 +51,7 @@ class EncryptAuthTokens implements DataPatchInterface
 
         foreach ($rows as $row) {
             $value = $row['value'];
-            if ($value === null || $value === '' || preg_match('/^\d+:\d+:/', $value)) {
+            if ($value === null || $value === '' || $this->isEncryptedToken($value)) {
                 continue;
             }
 
@@ -64,6 +64,17 @@ class EncryptAuthTokens implements DataPatchInterface
 
         $this->cacheTypeList->cleanType(Config::TYPE_IDENTIFIER);
         $this->moduleDataSetup->endSetup();
+    }
+
+    private function isEncryptedToken($value)
+    {
+        try {
+            $decryptedValue = $this->encryptor->decrypt($value);
+        } catch (\Throwable $exception) {
+            return false;
+        }
+
+            return $decryptedValue !== '' && $decryptedValue !== $value;
     }
 
     public static function getDependencies()


### PR DESCRIPTION
M3 - https://bread-financial.atlassian.net/browse/APEX-8711

Note: We added WriterInterface $configWriter to Data so it could encrypt and save tokens centrally. Every child class that manually calls parent::__construct() must pass that new argument. Otherwise Magento receives too few arguments, which throws errors.